### PR TITLE
Add dynamic graph generation stub

### DIFF
--- a/AGENT_CHANGES.md
+++ b/AGENT_CHANGES.md
@@ -1,0 +1,13 @@
+# Agent Changes
+
+## Dynamic Graph Engine Prototype
+
+- Added a new `workflow/dynamic` package defining a `NodeGenerator` interface. `DefaultGenerator` can be replaced to provide custom step generation logic.
+- Introduced `FileGenerator` which reads a YAML file mapping node names to additional `WorkflowStep`s. The file path is taken from the `DYNAMIC_STEPS_PATH` environment variable.
+- `workflow/controller/operator.go` now calls the generator when a node completes. Generated steps are executed sequentially and added as children of the completed node.
+
+This remains an experimental feature. A full dynamic engine would require deeper integration with the workflow controller and API changes.
+
+### Development Notes
+
+Running lint or vet locally requires a placeholder UI build. Execute `make ui/dist/app/index.html` before `go vet` to avoid missing file errors.

--- a/AGENT_CHANGES.md
+++ b/AGENT_CHANGES.md
@@ -4,7 +4,6 @@
 
 - Added a new `workflow/dynamic` package defining a `NodeGenerator` interface. `DefaultGenerator` can be replaced to provide custom step generation logic.
 - Introduced `FileGenerator` which reads a YAML file mapping node names to additional `WorkflowStep`s. The file path is taken from the `DYNAMIC_STEPS_PATH` environment variable.
-- Added `ContainerGenerator` which runs a Docker image (set via `DYNAMIC_GENERATOR_IMAGE`) to return YAML describing steps on stdout. Optional command arguments can be provided via `DYNAMIC_GENERATOR_COMMAND`.
 - `workflow/controller/operator.go` now calls the generator when a node completes. Generated steps are executed sequentially and added as children of the completed node.
 
 This remains an experimental feature. A full dynamic engine would require deeper integration with the workflow controller and API changes.
@@ -13,19 +12,17 @@ This remains an experimental feature. A full dynamic engine would require deeper
 
 `examples/dynamic-file-generator.yaml` uses a simple file-based mapping defined in `examples/dynamic-steps.yaml`.
 
+`examples/dynamic-template.yaml` shows the same approach using a `WorkflowTemplate`.
+
 Run:
 
 ```bash
 export DYNAMIC_STEPS_PATH=examples/dynamic-steps.yaml
 argo submit --watch examples/dynamic-file-generator.yaml
+# or
+# argo submit --watch --from workflowtemplate/dynamic-template
 ```
 
-`examples/dynamic-container-generator.yaml` invokes a custom Docker image using `DYNAMIC_GENERATOR_IMAGE`. The container should output a YAML array of steps to stdout.
-
-```bash
-export DYNAMIC_GENERATOR_IMAGE=myorg/argo-generator:latest
-argo submit --watch examples/dynamic-container-generator.yaml
-```
 
 ### Development Notes
 

--- a/AGENT_CHANGES.md
+++ b/AGENT_CHANGES.md
@@ -4,9 +4,28 @@
 
 - Added a new `workflow/dynamic` package defining a `NodeGenerator` interface. `DefaultGenerator` can be replaced to provide custom step generation logic.
 - Introduced `FileGenerator` which reads a YAML file mapping node names to additional `WorkflowStep`s. The file path is taken from the `DYNAMIC_STEPS_PATH` environment variable.
+- Added `ContainerGenerator` which runs a Docker image (set via `DYNAMIC_GENERATOR_IMAGE`) to return YAML describing steps on stdout. Optional command arguments can be provided via `DYNAMIC_GENERATOR_COMMAND`.
 - `workflow/controller/operator.go` now calls the generator when a node completes. Generated steps are executed sequentially and added as children of the completed node.
 
 This remains an experimental feature. A full dynamic engine would require deeper integration with the workflow controller and API changes.
+
+### Example Workflows
+
+`examples/dynamic-file-generator.yaml` uses a simple file-based mapping defined in `examples/dynamic-steps.yaml`.
+
+Run:
+
+```bash
+export DYNAMIC_STEPS_PATH=examples/dynamic-steps.yaml
+argo submit --watch examples/dynamic-file-generator.yaml
+```
+
+`examples/dynamic-container-generator.yaml` invokes a custom Docker image using `DYNAMIC_GENERATOR_IMAGE`. The container should output a YAML array of steps to stdout.
+
+```bash
+export DYNAMIC_GENERATOR_IMAGE=myorg/argo-generator:latest
+argo submit --watch examples/dynamic-container-generator.yaml
+```
 
 ### Development Notes
 

--- a/examples/dynamic-container-generator.yaml
+++ b/examples/dynamic-container-generator.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: dynamic-container-
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    steps:
+    - - name: start
+        template: whalesay
+        arguments:
+          parameters:
+          - name: message
+            value: start
+  - name: whalesay
+    inputs:
+      parameters:
+      - name: message
+    container:
+      image: docker/whalesay:latest
+      command: [cowsay]
+      args: ["{{inputs.parameters.message}}"]

--- a/examples/dynamic-file-generator.yaml
+++ b/examples/dynamic-file-generator.yaml
@@ -2,6 +2,9 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: dynamic-file-
+# Submit with:
+#   export DYNAMIC_STEPS_PATH=examples/dynamic-steps.yaml
+#   argo submit --watch examples/dynamic-file-generator.yaml
 spec:
   entrypoint: main
   templates:

--- a/examples/dynamic-file-generator.yaml
+++ b/examples/dynamic-file-generator.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: dynamic-file-
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    steps:
+    - - name: hello
+        template: whalesay
+        arguments:
+          parameters:
+          - name: message
+            value: hello
+    - - name: maybe-more
+        template: whalesay
+        arguments:
+          parameters:
+          - name: message
+            value: original
+  - name: whalesay
+    inputs:
+      parameters:
+      - name: message
+    container:
+      image: docker/whalesay:latest
+      command: [cowsay]
+      args: ["{{inputs.parameters.message}}"]

--- a/examples/dynamic-steps.yaml
+++ b/examples/dynamic-steps.yaml
@@ -1,0 +1,7 @@
+maybe-more:
+  - name: dynamic-step
+    template: whalesay
+    arguments:
+      parameters:
+      - name: message
+        value: dynamic message

--- a/examples/dynamic-template.yaml
+++ b/examples/dynamic-template.yaml
@@ -1,7 +1,10 @@
 apiVersion: argoproj.io/v1alpha1
-kind: Workflow
+kind: WorkflowTemplate
 metadata:
-  generateName: dynamic-container-
+  name: dynamic-template
+# Submit with:
+#   export DYNAMIC_STEPS_PATH=examples/dynamic-steps.yaml
+#   argo submit --watch --from workflowtemplate/dynamic-template
 spec:
   entrypoint: main
   templates:

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -57,6 +57,7 @@ import (
 	controllercache "github.com/argoproj/argo-workflows/v3/workflow/controller/cache"
 	"github.com/argoproj/argo-workflows/v3/workflow/controller/estimation"
 	"github.com/argoproj/argo-workflows/v3/workflow/controller/indexes"
+	"github.com/argoproj/argo-workflows/v3/workflow/dynamic"
 	"github.com/argoproj/argo-workflows/v3/workflow/metrics"
 	"github.com/argoproj/argo-workflows/v3/workflow/progress"
 	"github.com/argoproj/argo-workflows/v3/workflow/templateresolution"
@@ -2365,6 +2366,30 @@ func (woc *wfOperationCtx) handleNodeFulfilled(ctx context.Context, nodeName str
 		if prevNodeStatus, ok := woc.preExecutionNodePhases[node.ID]; ok && !prevNodeStatus.Fulfilled() {
 			localScope, realTimeScope := woc.prepareMetricScope(node)
 			woc.computeMetrics(ctx, processedTmpl.Metrics.Prometheus, localScope, realTimeScope, false)
+		}
+	}
+
+	// Attempt to generate additional workflow steps dynamically using the
+	// global dynamic graph generator. This is a best-effort operation that
+	// executes the generated steps sequentially under the current node.
+	if generated, err := dynamic.DefaultGenerator.Generate(woc.wf, nodeName); err != nil {
+		woc.log.WithError(err).Error("dynamic graph generation failed")
+	} else if len(generated) > 0 {
+		woc.log.Infof("generated %d dynamic steps for %s", len(generated), nodeName)
+		tmplCtx, err := woc.createTemplateContext(wfv1.ResourceScopeLocal, "")
+		if err != nil {
+			woc.log.WithError(err).Error("failed to create template context for dynamic steps")
+		} else {
+			for i, step := range generated {
+				dynNodeName := fmt.Sprintf("%s.dynamic.%d", nodeName, i)
+				child, err := woc.executeTemplate(ctx, dynNodeName, &step, tmplCtx, step.Arguments, &executeTemplateOpts{boundaryID: nodeName})
+				if err != nil {
+					woc.log.WithError(err).Errorf("dynamic step %s failed", dynNodeName)
+				}
+				if child != nil {
+					woc.addChildNode(nodeName, dynNodeName)
+				}
+			}
 		}
 	}
 	return node

--- a/workflow/dynamic/dynamic.go
+++ b/workflow/dynamic/dynamic.go
@@ -1,10 +1,7 @@
 package dynamic
 
 import (
-	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"gopkg.in/yaml.v3"
@@ -52,51 +49,12 @@ func (f FileGenerator) Generate(wf *wfv1.Workflow, nodeName string) ([]wfv1.Work
 	return m[nodeName], nil
 }
 
-// ContainerGenerator runs a Docker container to produce workflow steps. The
-// container's stdout must contain a YAML array of `WorkflowStep` objects.
-// The workflow and node names are provided via WORKFLOW_NAME and NODE_NAME
-// environment variables.
-type ContainerGenerator struct {
-	Image   string
-	Command []string
-}
-
-// Generate executes the container and parses the resulting steps.
-func (c ContainerGenerator) Generate(wf *wfv1.Workflow, nodeName string) ([]wfv1.WorkflowStep, error) {
-	if c.Image == "" {
-		return nil, nil
-	}
-	args := []string{"run", "--rm", c.Image}
-	args = append(args, c.Command...)
-	cmd := exec.Command("docker", args...)
-	cmd.Env = append(os.Environ(),
-		fmt.Sprintf("WORKFLOW_NAME=%s", wf.Name),
-		fmt.Sprintf("NODE_NAME=%s", nodeName),
-	)
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, err
-	}
-	var steps []wfv1.WorkflowStep
-	if err := yaml.Unmarshal(out, &steps); err != nil {
-		return nil, err
-	}
-	return steps, nil
-}
-
 // DefaultGenerator is the global node generator used by the workflow
 // controller. It can be replaced at startup to provide custom implementations.
 var DefaultGenerator NodeGenerator = noopGenerator{}
 
 func init() {
-	if image := os.Getenv("DYNAMIC_GENERATOR_IMAGE"); image != "" {
-		cmdStr := os.Getenv("DYNAMIC_GENERATOR_COMMAND")
-		var cmd []string
-		if cmdStr != "" {
-			cmd = strings.Split(cmdStr, " ")
-		}
-		DefaultGenerator = ContainerGenerator{Image: image, Command: cmd}
-	} else if os.Getenv("DYNAMIC_STEPS_PATH") != "" {
+	if os.Getenv("DYNAMIC_STEPS_PATH") != "" {
 		DefaultGenerator = FileGenerator{}
 	}
 }

--- a/workflow/dynamic/dynamic.go
+++ b/workflow/dynamic/dynamic.go
@@ -1,0 +1,54 @@
+package dynamic
+
+import (
+	"os"
+
+	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	"gopkg.in/yaml.v3"
+)
+
+// NodeGenerator defines an interface for objects that can generate additional
+// workflow steps at runtime based on the current workflow and node name.
+type NodeGenerator interface {
+	Generate(wf *wfv1.Workflow, nodeName string) ([]wfv1.WorkflowStep, error)
+}
+
+// noopGenerator implements NodeGenerator and returns no new steps. It is used
+// as the default generator when dynamic graph execution is not configured.
+type noopGenerator struct{}
+
+// Generate always returns no steps.
+func (noopGenerator) Generate(wf *wfv1.Workflow, nodeName string) ([]wfv1.WorkflowStep, error) {
+	return nil, nil
+}
+
+// FileGenerator loads dynamic steps from a YAML file. The YAML file should map
+// node names to arrays of workflow steps. If Path is empty, the file path is
+// read from the DYNAMIC_STEPS_PATH environment variable.
+type FileGenerator struct {
+	Path string
+}
+
+// Generate reads the mapping file and returns any steps for the given node.
+func (f FileGenerator) Generate(wf *wfv1.Workflow, nodeName string) ([]wfv1.WorkflowStep, error) {
+	path := f.Path
+	if path == "" {
+		path = os.Getenv("DYNAMIC_STEPS_PATH")
+	}
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	m := map[string][]wfv1.WorkflowStep{}
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	return m[nodeName], nil
+}
+
+// DefaultGenerator is the global node generator used by the workflow
+// controller. It can be replaced at startup to provide custom implementations.
+var DefaultGenerator NodeGenerator = noopGenerator{}

--- a/workflow/dynamic/dynamic.go
+++ b/workflow/dynamic/dynamic.go
@@ -1,7 +1,10 @@
 package dynamic
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"gopkg.in/yaml.v3"
@@ -49,6 +52,51 @@ func (f FileGenerator) Generate(wf *wfv1.Workflow, nodeName string) ([]wfv1.Work
 	return m[nodeName], nil
 }
 
+// ContainerGenerator runs a Docker container to produce workflow steps. The
+// container's stdout must contain a YAML array of `WorkflowStep` objects.
+// The workflow and node names are provided via WORKFLOW_NAME and NODE_NAME
+// environment variables.
+type ContainerGenerator struct {
+	Image   string
+	Command []string
+}
+
+// Generate executes the container and parses the resulting steps.
+func (c ContainerGenerator) Generate(wf *wfv1.Workflow, nodeName string) ([]wfv1.WorkflowStep, error) {
+	if c.Image == "" {
+		return nil, nil
+	}
+	args := []string{"run", "--rm", c.Image}
+	args = append(args, c.Command...)
+	cmd := exec.Command("docker", args...)
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("WORKFLOW_NAME=%s", wf.Name),
+		fmt.Sprintf("NODE_NAME=%s", nodeName),
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	var steps []wfv1.WorkflowStep
+	if err := yaml.Unmarshal(out, &steps); err != nil {
+		return nil, err
+	}
+	return steps, nil
+}
+
 // DefaultGenerator is the global node generator used by the workflow
 // controller. It can be replaced at startup to provide custom implementations.
 var DefaultGenerator NodeGenerator = noopGenerator{}
+
+func init() {
+	if image := os.Getenv("DYNAMIC_GENERATOR_IMAGE"); image != "" {
+		cmdStr := os.Getenv("DYNAMIC_GENERATOR_COMMAND")
+		var cmd []string
+		if cmdStr != "" {
+			cmd = strings.Split(cmdStr, " ")
+		}
+		DefaultGenerator = ContainerGenerator{Image: image, Command: cmd}
+	} else if os.Getenv("DYNAMIC_STEPS_PATH") != "" {
+		DefaultGenerator = FileGenerator{}
+	}
+}

--- a/workflow/dynamic/dynamic_test.go
+++ b/workflow/dynamic/dynamic_test.go
@@ -1,0 +1,33 @@
+package dynamic
+
+import (
+	"os"
+	"testing"
+
+	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+)
+
+func TestFileGenerator(t *testing.T) {
+	content := "step:\n  - name: dyn\n    template: whalesay\n"
+	f, err := os.CreateTemp("", "dynsteps*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	g := FileGenerator{Path: f.Name()}
+	steps, err := g.Generate(&wfv1.Workflow{}, "step")
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if len(steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(steps))
+	}
+	if steps[0].Name != "dyn" {
+		t.Fatalf("unexpected step name: %s", steps[0].Name)
+	}
+}


### PR DESCRIPTION
## Summary
- add `workflow/dynamic` package with `NodeGenerator` interface
- call the default generator in `handleNodeFulfilled` and execute returned steps
- implement `FileGenerator` to load steps from YAML via `DYNAMIC_STEPS_PATH`
- document dynamic engine prototype in `AGENT_CHANGES.md`

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6857afbf2fdc8333be72e23cfbb70b00